### PR TITLE
Add deposit and withdraw

### DIFF
--- a/cogs/deposit.py
+++ b/cogs/deposit.py
@@ -1,0 +1,32 @@
+import discord
+from discord.ext import commands
+from discord import app_commands
+from data.data_manager import get_or_create_user_data, save_user_data
+
+class Deposit(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @app_commands.command(name="deposit", description="Deposit money into your bank.")
+    @app_commands.describe(amount="The amount to deposit.")
+    async def deposit(self, interaction: discord.Interaction, amount: int):
+        if amount <= 0:
+            return await interaction.response.send_message("You must deposit a positive amount.", ephemeral=True)
+
+        user = interaction.user
+        user_id = str(user.id)
+        users = get_or_create_user_data(user_id)
+        data = users[user_id]
+
+        if data["balance"] < amount:
+            return await interaction.response.send_message("You don't have enough money to deposit.", ephemeral=True)
+
+        data["balance"] -= amount
+        data["deposit"] = data.get("deposit", 0) + amount
+        users[user_id] = data
+        save_user_data(users)
+
+        await interaction.response.send_message(f"You have deposited ${amount} into your bank.", ephemeral=True)
+
+async def setup(bot):
+    await bot.add_cog(Deposit(bot))

--- a/cogs/wallet.py
+++ b/cogs/wallet.py
@@ -23,6 +23,7 @@ class CardCog(commands.Cog):
             title=f"{user.name}'s Profile Wallet :3",
             color=discord.Color.purple(),
             description=f"**Balance:** ${balance}\n"
+                        f"**Deposit:** ${user_data.get('deposit', 0)}\n"
                         f"**Fish in Inventory:** {fish_count}\n"
                         f"**Inventory Worth:** ${inventory_worth}\n"
                         f"**Sold Fish:** {sold_count}"

--- a/cogs/withdraw.py
+++ b/cogs/withdraw.py
@@ -1,0 +1,32 @@
+import discord
+from discord.ext import commands
+from discord import app_commands
+from data.data_manager import get_or_create_user_data, save_user_data
+
+class Withdraw(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @app_commands.command(name="withdraw", description="Withdraw money from your bank.")
+    @app_commands.describe(amount="The amount to withdraw.")
+    async def withdraw(self, interaction: discord.Interaction, amount: int):
+        if amount <= 0:
+            return await interaction.response.send_message("You must withdraw a positive amount.", ephemeral=True)
+
+        user = interaction.user
+        user_id = str(user.id)
+        users = get_or_create_user_data(user_id)
+        data = users[user_id]
+
+        if data.get("deposit", 0) < amount:
+            return await interaction.response.send_message("You don't have enough money in your bank to withdraw.", ephemeral=True)
+
+        data["deposit"] -= amount
+        data["balance"] = data.get("balance", 0) + amount
+        users[user_id] = data
+        save_user_data(users)
+
+        await interaction.response.send_message(f"You have withdrawn ${amount} from your bank.", ephemeral=True)
+
+async def setup(bot):
+    await bot.add_cog(Withdraw(bot))

--- a/data/data_manager.py
+++ b/data/data_manager.py
@@ -55,6 +55,7 @@ def get_or_create_user_data(user_id):
             "equipped_rod": None,
             "fish": [],
             "balance": 0,
+            "deposit": 0,
             "sold_fish": []
         }
     


### PR DESCRIPTION
This PR adds both `deposit` and `withdraw` commands. The `deposit` command can be used to hide your money into a deposit so players cannot rob you, but you cannot use that money until you use `withdraw` to withdraw the amount of balance you need.

### Example
If you have a balance of `200`, you run `/deposit 200`, you now have a balance of `0` and cannot use a command like `/gift <user> 200` or `/cockfight 200`.